### PR TITLE
Rename Index.atIndex -> Index.at

### DIFF
--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -92,7 +92,9 @@ open class PageboyViewController: UIViewController {
         case previous
         case first
         case last
+        @available(*, deprecated: 1.0.3, message: "Use at(index: Int)")
         case atIndex(index: Int)
+        case at(index: Int)
     }
     
     
@@ -407,8 +409,11 @@ internal extension PageboyViewController {
             
         case .last:
             return (self.viewControllers?.count ?? 1) - 1
-            
+
         case .atIndex(let index):
+            return index
+
+        case .at(let index):
             return index
         }
     }


### PR DESCRIPTION
I've renamed following.
`PageIndex.atIndex(index: Int)` -> `PageIndex.at(index: Int)`

Then you can initialize it as follows.
```
.at(index: 3)
```

What do yo think?
