### PR TITLE
Fix infinite scrolling issues.

### DIFF
--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -313,7 +313,18 @@ open class PageboyViewController: UIViewController {
             guard rawIndex >= 0 && rawIndex < self.viewControllers?.count ?? 0 else { return }
             guard let viewController = self.viewControllers?[rawIndex] else { return }
             
-            let direction = NavigationDirection.forPage(rawIndex, previousPage: self.currentIndex ?? rawIndex)
+            var direction = NavigationDirection.forPage(rawIndex, previousPage: self.currentIndex ?? rawIndex)
+            
+            if isInfiniteScrollEnabled {
+                switch pageIndex {
+                case .next:
+                    direction = .forward
+                case .previous:
+                    direction = .reverse
+                default: break
+                }
+            }
+            
             self.pageViewController(self.pageViewController,
                                     willTransitionTo: [viewController],
                                     animated: animated)
@@ -411,7 +422,7 @@ internal extension PageboyViewController {
             }
             var proposedIndex = currentIndex - 1
             if self.isInfiniteScrollEnabled && proposedIndex < 0 { // scroll to last index
-                proposedIndex = 0
+                proposedIndex = (self.viewControllers?.count ?? 1) - 1
             }
             return proposedIndex
             


### PR DESCRIPTION
There were a couple of issues when using `scrollToPage` on a pager that had `isInfiniteScrollEnabled` set to `true`.

- `.next` used the wrong direction when animating from the last page to the first.
- `.previous` did not work at all when trying to scroll from the first page to the last.