### PR TITLE
Make PageboyViewControllerDelegate functions optional

### DIFF
--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -464,7 +464,7 @@ extension PageboyViewController: PageboyAutoScrollerHandler {
 }
 
 // MARK: - PageboyViewControllerDelegate default implementations
-extension PageboyViewControllerDelegate {
+public extension PageboyViewControllerDelegate {
     func pageboyViewController(_ pageboyViewController: PageboyViewController,
                                willScrollToPageAtIndex index: Int,
                                direction: PageboyViewController.NavigationDirection,

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -462,3 +462,26 @@ extension PageboyViewController: PageboyAutoScrollerHandler {
         self.scrollToPage(.next, animated: animated)
     }
 }
+
+// MARK: - PageboyViewControllerDelegate default implementations
+extension PageboyViewControllerDelegate {
+    func pageboyViewController(_ pageboyViewController: PageboyViewController,
+                               willScrollToPageAtIndex index: Int,
+                               direction: PageboyViewController.NavigationDirection,
+                               animated: Bool) {}
+    
+    func pageboyViewController(_ pageboyViewController: PageboyViewController,
+                               didScrollToPosition position: CGPoint,
+                               direction: PageboyViewController.NavigationDirection,
+                               animated: Bool) {}
+    
+    func pageboyViewController(_ pageboyViewController: PageboyViewController,
+                               didScrollToPageAtIndex index: Int,
+                               direction: PageboyViewController.NavigationDirection,
+                               animated: Bool) {}
+    
+    func pageboyViewController(_ pageboyViewController: PageboyViewController,
+                               didReload viewControllers: [UIViewController],
+                               currentIndex: PageboyViewController.PageIndex) {}
+
+}


### PR DESCRIPTION
By providing default implementations in an extension, classes that adopt `PageboyViewControllerDelegate` can implement just the methods they're interested in. (This is equivalent to marking the method `@optional` in Objective-C)