### PR TITLE
fix nan position

### DIFF
--- a/Sources/Pageboy/Extensions/PageboyViewController+ScrollDetection.swift
+++ b/Sources/Pageboy/Extensions/PageboyViewController+ScrollDetection.swift
@@ -276,7 +276,8 @@ extension PageboyViewController: UIPageViewControllerDelegate, UIScrollViewDeleg
         
         let scrollOffset = contentOffset - pageSize
         let pageOffset = (CGFloat(currentIndex) * pageSize) + (scrollOffset * indexDiff)
-        return pageOffset / pageSize
+        let position = pageOffset / pageSize
+        return position.isFinite ? position : 0
     }
     
     /// Update the scroll view contentOffset for bouncing preference if required.


### PR DESCRIPTION
I used it as child view contoller.
I faced an issue when my pager `scrollView` had `.zero` frame (maybe it happens before applying constrains), not sure exactly how. 
When it is `.zero`, position becomes `NaN` and then it tries to assign to constraint value which is causing a crash.
At the end I'm getting it fine without any constraint warnings.
This is not changing any logic, just preventing a crash if there is some bad value in `position`