### PR TITLE
Add Right-to-Left interface layout support when using iOS 8

### DIFF
--- a/Sources/Pageboy/Utilities/LocalizationUtils.swift
+++ b/Sources/Pageboy/Utilities/LocalizationUtils.swift
@@ -15,8 +15,7 @@ extension UIView {
         if #available(iOS 9.0, *) {
             return UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft
         } else {
-            // Fallback on earlier versions
-            return false
+            return UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft
         }
     }
     


### PR DESCRIPTION
- Fix missing fallback for devices running iOS lower than `9.0` that were unable to use `userInterfaceLayoutDirection(for:)`.