### PR TITLE
Fixed Memory leaking issue #83

### DIFF
--- a/Example/Pageboy-Example/TransparentNavigationBar.swift
+++ b/Example/Pageboy-Example/TransparentNavigationBar.swift
@@ -18,7 +18,10 @@ class TransparentNavigationBar: UINavigationBar {
         var titleTextAttributes: [String : Any] = [NSForegroundColorAttributeName : UIColor.white]
         if #available(iOS 8.2, *) {
             titleTextAttributes[NSFontAttributeName] = UIFont.systemFont(ofSize: 18.0, weight: UIFontWeightRegular)
+        }else{
+            titleTextAttributes[NSFontAttributeName] = UIFont.systemFont(ofSize: 18.0)
         }
+        
         self.titleTextAttributes = titleTextAttributes
         self.tintColor = UIColor.white.withAlphaComponent(0.7)
         

--- a/Sources/Pageboy/Extensions/PageboyViewController+Transitioning.swift
+++ b/Sources/Pageboy/Extensions/PageboyViewController+Transitioning.swift
@@ -88,6 +88,10 @@ internal extension PageboyViewController {
         guard self.activeTransition == nil else { return }
         guard let pageViewController = self.pageViewController else { return }
         
+        // setup Transition 
+        // fixed issue #83 https://github.com/uias/Pageboy/issues/83
+        self.setUpTransitioning()
+        
         /// Calculate semantic direction for RtL languages
         var semanticDirection = direction
         if view.layoutIsRightToLeft && navigationOrientation == .horizontal {
@@ -117,6 +121,10 @@ extension PageboyViewController: TransitionOperationDelegate {
                              didFinish finished: Bool) {
         self.transitionDisplayLink?.isPaused = true
         self.activeTransition = nil
+        
+        // fixed issue #83 https://github.com/uias/Pageboy/issues/83
+        self.transitionDisplayLink?.invalidate()
+        self.transitionDisplayLink = nil
     }
     
     func transitionOperation(_ operation: TransitionOperation,

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -249,15 +249,22 @@ open class PageboyViewController: UIViewController {
     /// Auto Scroller for automatic time-based page transitions.
     public let autoScroller = PageboyAutoScroller()
     
+    
+    // MARK: object LifeCycle
+    deinit{
+        
+        self.viewControllers?.removeAll()
+    }
+    
     // MARK: Lifecycle
 
     open override func viewDidLoad() {
         super.viewDidLoad()
         
         self.autoScroller.handler = self
-        self.setUpTransitioning()
         self.setUpPageViewController()
     }
+
     
     open override func viewWillTransition(to size: CGSize,
                                           with coordinator: UIViewControllerTransitionCoordinator) {

--- a/Sources/Pageboy/Utilities/TransitionOperation.swift
+++ b/Sources/Pageboy/Utilities/TransitionOperation.swift
@@ -43,7 +43,8 @@ internal class TransitionOperation: NSObject, CAAnimationDelegate {
     let action: Action
     
     /// The raw animation for the operation.
-    private var animation: CATransition
+    private var animation: CATransition? // fixed issue #83 https://github.com/uias/Pageboy/issues/83
+    
     /// Whether the operation is currently animating.
     private var isAnimating: Bool = false
     
@@ -86,8 +87,10 @@ internal class TransitionOperation: NSObject, CAAnimationDelegate {
                completion: @escaping Completion) {
         self.completion = completion
         self.startTime = CACurrentMediaTime()
-        layer.add(self.animation,
-                  forKey: "transition")
+        if let animation = self.animation {
+            layer.add(animation,
+                      forKey: "transition")
+        }
     }
     
     /// Perform a frame tick on the transition.
@@ -96,10 +99,17 @@ internal class TransitionOperation: NSObject, CAAnimationDelegate {
         delegate?.transitionOperation(self, didUpdateWith: percentComplete)
     }
     
+    
+    
+    
     /// The total duration of the transition.
     var duration: CFTimeInterval {
+        guard let animation = self.animation else {
+            return 0.0
+        }
         return animation.duration
     }
+    
     /// The percent that the transition is complete.
     var percentComplete: CGFloat {
         guard self.isAnimating else { return 0.0 }
@@ -118,6 +128,7 @@ internal class TransitionOperation: NSObject, CAAnimationDelegate {
         isAnimating = false
         completion?(flag)
         delegate?.transitionOperation(self, didFinish: flag)
+        self.animation = nil
     }
 }
 


### PR DESCRIPTION
Hi Dear
@msaps I found the leaking object which holds `pageboyViewController` and doesn't allow to deallocate `pageboyViewController` after pop or dismiss

- Fixed strong reference in CADisplayLink
- Clear viewControllers content after deallocated 
- Fixed animation property strong reference

issue reference : [MemoryLeak](https://github.com/uias/Pageboy/issues/83)