### PR TITLE
Set constraints after addSubview for In-Call StatusBar mode

### DIFF
--- a/Sources/Pageboy/Extensions/PageboyViewController+Management.swift
+++ b/Sources/Pageboy/Extensions/PageboyViewController+Management.swift
@@ -54,15 +54,16 @@ internal extension PageboyViewController {
         self.pageViewController = pageViewController
         
         self.addChildViewController(pageViewController)
-        pageViewController.view.pinToSuperviewEdges()
-        
+      
         if let existingZIndex = existingZIndex {
             self.view.insertSubview(pageViewController.view, at: existingZIndex)
         } else {
             self.view.addSubview(pageViewController.view)
             self.view.sendSubview(toBack: pageViewController.view)
         }
-        
+      
+        pageViewController.view.pinToSuperviewEdges()
+      
         pageViewController.scrollView?.delegate = self
         pageViewController.view.backgroundColor = .clear
         pageViewController.scrollView?.delaysContentTouches = delaysContentTouches


### PR DESCRIPTION
When In-Call StatusBar Mode, UIPageViewController will have Top-margin.
I've moved pinToSuperviewEdges after addSubview.

But, pinToSuperviewEdges always guard-return in existing code.
Do you have any reasons for it?

I've attached screenshots below.
What do you think?

Before

ViewTree has double top-margin.

<img width="294" alt="screen shot 2017-06-29 at 15 05 46" src="https://user-images.githubusercontent.com/1888355/27673600-7ee920aa-5cdc-11e7-9753-fa53845430aa.png">

After

ViewTree has single top-margin.

<img width="318" alt="screen shot 2017-06-29 at 15 06 45" src="https://user-images.githubusercontent.com/1888355/27673631-9a0cc332-5cdc-11e7-8e46-2fa6602b0e75.png">

![simulator screen shot jun 29 2017 15 10 25](https://user-images.githubusercontent.com/1888355/27673709-18938ba0-5cdd-11e7-97d4-29197047c994.png)
