### PR TITLE
Update cocoapods instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For Swift 3.x support, please use the latest [1.x release](https://github.com/ui
 ### CocoaPods
 Pageboy is available through [CocoaPods](http://cocoapods.org). To install it, simply add the following line to your Podfile:
 ```ruby
-pod 'Pageboy' ~> 2.0
+pod 'Pageboy', '~> 2.0'
 ```
 And run `pod install`.
 


### PR DESCRIPTION
I believe there was an error in the cocoapods instructions - I copied and pasted the installation line (`pod 'Pageboy' ~> 2.0`) and got a syntax error. I've changed it to `pod 'Pageboy', '~> 2.0'`