### PR TITLE
Improve blocking logic for animated scrolling operations

### DIFF
--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -278,11 +278,11 @@ open class PageboyViewController: UIViewController {
             return self.pageViewController?.viewControllers?.last
         }
     }
-    internal var isCurrentlyOnPageIndex: Bool {
+    /// Whether the page view controller position is currently resting on a page index.
+    internal var isPositionedOnPageIndex: Bool {
         let currentPosition = navigationOrientation == .horizontal ? self.currentPosition?.x : self.currentPosition?.y
         return currentPosition?.truncatingRemainder(dividingBy: 1) == 0
     }
-    
     
     /// Auto Scroller for automatic time-based page transitions.
     public let autoScroller = PageboyAutoScroller()
@@ -325,7 +325,7 @@ open class PageboyViewController: UIViewController {
         // guard against any current transition operation
         guard self.isScrollingAnimated == false else { return false }
         guard !(self.isTracking && self.isDragging && self.isDecelerating) else { return false }
-        guard self.isCurrentlyOnPageIndex else { return false }
+        guard self.isPositionedOnPageIndex else { return false }
         guard let pageViewController = self.pageViewController else { return false }
         
         let rawIndex = self.indexValue(for: page)

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -187,6 +187,10 @@ open class PageboyViewController: UIViewController {
     public var isDragging: Bool {
             return self.pageViewController?.scrollView?.isDragging ?? false
     }
+    // Wether the user isn't dragging (touch up) but page view controller is still moving.
+    public var isDecelerating: Bool {
+        return self.pageViewController?.scrollView?.isDecelerating ?? false
+    }
     /// Whether user interaction is enabled on the page view controller.
     ///
     /// Default is TRUE
@@ -316,7 +320,7 @@ open class PageboyViewController: UIViewController {
         
         // guard against any current transition operation
         guard self.isScrollingAnimated == false else { return false }
-        guard self.isTracking == false else { return false }
+        guard !(self.isTracking && self.isDragging && self.isDecelerating) else { return false }
         guard let pageViewController = self.pageViewController else { return false }
         
         let rawIndex = self.indexValue(for: page)

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -278,6 +278,10 @@ open class PageboyViewController: UIViewController {
             return self.pageViewController?.viewControllers?.last
         }
     }
+    internal var isCurrentlyOnPageIndex: Bool {
+        let currentPosition = navigationOrientation == .horizontal ? self.currentPosition?.x : self.currentPosition?.y
+        return currentPosition?.truncatingRemainder(dividingBy: 1) == 0
+    }
     
     
     /// Auto Scroller for automatic time-based page transitions.
@@ -321,6 +325,7 @@ open class PageboyViewController: UIViewController {
         // guard against any current transition operation
         guard self.isScrollingAnimated == false else { return false }
         guard !(self.isTracking && self.isDragging && self.isDecelerating) else { return false }
+        guard self.isCurrentlyOnPageIndex else { return false }
         guard let pageViewController = self.pageViewController else { return false }
         
         let rawIndex = self.indexValue(for: page)


### PR DESCRIPTION
Improve the logic that handles decided whether to proceed with an animated scroll operation while another scroll operation could be occurring.

Improvements to help resolve #109 