### PR TITLE
Fix issue where updateViewControllers would fail

### DIFF
--- a/Sources/Pageboy/Extensions/PageboyViewController+Management.swift
+++ b/Sources/Pageboy/Extensions/PageboyViewController+Management.swift
@@ -30,6 +30,7 @@ public extension PageboyViewController {
         updateViewControllers(to: [currentViewController],
                               animated: false,
                               async: false,
+                              force: false,
                               completion: nil)
     }
 }
@@ -43,10 +44,15 @@ internal extension PageboyViewController {
                                direction: NavigationDirection = .forward,
                                animated: Bool,
                                async: Bool,
+                               force: Bool,
                                completion: TransitionOperation.Completion?) {
-        guard let pageViewController = self.pageViewController, !isUpdatingViewControllers else {
+        guard let pageViewController = self.pageViewController else {
             return
         }
+        if isUpdatingViewControllers && !force {
+            return
+        }
+        
         
         targetIndex = toIndex
         isUpdatingViewControllers = true
@@ -151,7 +157,7 @@ internal extension PageboyViewController {
                 return
         }
         
-        updateViewControllers(to: [viewController], animated: false, async: false) { _ in
+        updateViewControllers(to: [viewController], animated: false, async: false, force: false) { _ in
             self.currentIndex = defaultIndex
             self.delegate?.pageboyViewController(self,
                                                  didReloadWith: viewController,

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -315,6 +315,7 @@ public extension PageboyViewController {
                                       direction: direction,
                                       animated: animated,
                                       async: true,
+                                      force: force,
                                       completion: transitionCompletion)
                 
                 return true


### PR DESCRIPTION
#166 - When interrupted by a VC transition `updateViewControllers` would fail to complete and be in a locked state. Updated to allow for forced updates when an incorrect paging state is detected.