### PR TITLE
Fixed incorrect scrolling to index on pager appearance

### DIFF
--- a/Sources/Pageboy/Extensions/PageboyViewController+ScrollDetection.swift
+++ b/Sources/Pageboy/Extensions/PageboyViewController+ScrollDetection.swift
@@ -177,6 +177,7 @@ extension PageboyViewController: UIScrollViewDelegate {
             if self.autoScroller.restartsOnScrollEnd {
                 self.autoScroller.restart()
             }
+            self.expectedTransitionIndex = nil
         })
     }
     

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -301,6 +301,7 @@ public extension PageboyViewController {
                                                                  didScrollTo: currentPosition,
                                                                  direction: direction,
                                                                  animated: animated)
+                            self.expectedTransitionIndex = nil
                         }
                     }
                     


### PR DESCRIPTION
Issue Replication:
1. Begin to page to a new index but then stop the gesture early so that the pager stays on the current index
2. Present and dismiss a view controller over the pager
3. The pager will now be at the index that you had started to move to, but not the index that you ended at.

Cause:
expectedTransitionIndex on PageboyViewController is set when the user begins the paging gesture, however, the expectedTransitionIndex is never cleared and the currentIndex is never updated if the user cancels the gesture.  Therefore, when scrollToPage is triggered on viewWillAppear, the expectedTransitionIndex does not match the currentIndex and therefore the pager switches pages even though that is not the intention of the user.

Fix:
expectedTransitionIndex is set to nil at the end of the paging/scrolling process.