### PR TITLE
Add swiftlint disable to prevent build errors / warnings

### DIFF
--- a/Sources/Pageboy/Components/PageboyAutoScroller.swift
+++ b/Sources/Pageboy/Components/PageboyAutoScroller.swift
@@ -45,6 +45,7 @@ public class PageboyAutoScroller: Any {
     public enum IntermissionDuration {
         case short
         case long
+        // swiftlint:disable identifier_name
         case custom(duration: TimeInterval)
     }
     

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -265,6 +265,7 @@ public extension PageboyViewController {
     /// - parameter force: Whether to force the scroll, ignoring current animation & positional status.
     /// - parameter completion: The completion closure.
     /// - Returns: Whether the scroll was executed.
+    // swiftlint:disable function_body_length
     @discardableResult
     internal func scrollToPage(_ page: Page,
                                animated: Bool,


### PR DESCRIPTION
Not sure about Pod installation but via Carthage I was unable to build the framework without ignoring the `identifier_name` in `PageboyAutoScroller`. 