### PR TITLE
Thread Safety, closure captures, debug-only FatalErrors, self-self aliasing, misc tweaks

### DIFF
--- a/Sources/Pageboy/PageboyViewController+Management.swift
+++ b/Sources/Pageboy/PageboyViewController+Management.swift
@@ -82,10 +82,24 @@ internal extension PageboyViewController {
                                completion: TransitionOperation.Completion?) {
 
         if Thread.isMainThread {
-            _updateViewControllers(to: viewControllers, animated: animated, async: async, force: force, completion: completion)
+            _updateViewControllers(to: viewControllers,
+                                   from: fromIndex,
+                                   to: toIndex,
+                                   direction: direction,
+                                   animated: animated,
+                                   async: async, force:
+                                   force,
+                                   completion: completion)
         } else {
             DispatchQueue.main.sync {
-                _updateViewControllers(to: viewControllers, animated: animated, async: async, force: force, completion: completion)
+                _updateViewControllers(to: viewControllers,
+                                       from: fromIndex,
+                                       to: toIndex,
+                                       direction: direction,
+                                       animated: animated,
+                                       async: async,
+                                       force: force,
+                                       completion: completion)
             }
         }
     }

--- a/Sources/Pageboy/PageboyViewController+Updating.swift
+++ b/Sources/Pageboy/PageboyViewController+Updating.swift
@@ -34,7 +34,7 @@ internal extension PageboyViewController {
         }
         
         if newIndex == currentIndex {
-            pageViewController?.view.crossDissolve(during: { [weak self] in
+            pageViewController?.view.crossDissolve(during: { [weak self, viewController] in
                 self?.updateViewControllers(to: [viewController],
                                             animated: false,
                                             async: true,
@@ -50,7 +50,7 @@ internal extension PageboyViewController {
                     return
                 }
                 
-                updateViewControllers(to: [currentViewController], animated: false, async: true, force: false, completion: { [weak self] _ in
+                updateViewControllers(to: [currentViewController], animated: false, async: true, force: false, completion: { [weak self, newIndex, updateBehavior] _ in
                     self?.performScrollUpdate(to: newIndex, behavior: updateBehavior)
                 })
             } else { // Otherwise just perform scroll update
@@ -80,7 +80,7 @@ extension PageboyViewController {
         case .scrollTo(let index):
             scrollToPage(.at(index: index), animated: true)
             
-        default:()
+        default: break
         }
     }
     

--- a/Sources/Pageboy/Transitioning/PageboyViewController+Transitioning.swift
+++ b/Sources/Pageboy/Transitioning/PageboyViewController+Transitioning.swift
@@ -90,12 +90,20 @@ internal extension PageboyViewController {
                                     with direction: NavigationDirection,
                                     animated: Bool,
                                     completion: @escaping TransitionOperation.Completion) {
+
+        /// Note: This is (currently) only called from _updateViewControllers which is already on the main thread
+        assert(Thread.isMainThread)
+
         guard let transition = transition, animated == true, activeTransitionOperation == nil else {
                 completion(false)
                 return
         }
         guard let scrollView = pageViewController?.scrollView else {
+            #if DEBUG
             fatalError("Can't find UIPageViewController scroll view")
+            #else
+            return
+            #endif
         }
 
         prepareForTransition()
@@ -156,14 +164,14 @@ extension PageboyViewController: TransitionOperationDelegate {
     }
 }
 
-internal extension PageboyViewController.Transition {
+internal extension CATransition {
     
-    func configure(transition: inout CATransition) {
-        transition.duration = duration
+    func configure(from: PageboyViewController.Transition) {
+        duration = from.duration
         #if swift(>=4.2)
-        transition.type = CATransitionType(rawValue: style.rawValue)
+        type = CATransitionType(rawValue: from.style.rawValue)
         #else
-        transition.type = style.rawValue
+        type = from.style.rawValue
         #endif
     }
 }

--- a/Sources/Pageboy/Transitioning/TransitionOperation.swift
+++ b/Sources/Pageboy/Transitioning/TransitionOperation.swift
@@ -77,14 +77,16 @@ internal class TransitionOperation: NSObject, CAAnimationDelegate {
     init(for transition: PageboyViewController.Transition,
          action: Action,
          delegate: TransitionOperationDelegate) {
-        self.transition = transition
+
         self.action = action
         self.delegate = delegate
+        self.transition = transition
         
-        var animation = CATransition()
+        let animation = CATransition()
         animation.startProgress = 0.0
         animation.endProgress = 1.0
-        transition.configure(transition: &animation)
+        animation.configure(from: transition)
+
         animation.subtype = action.transitionSubType
         #if swift(>=4.2)
         animation.fillMode = .backwards

--- a/Sources/Pageboy/Utilities/Extensions/UIView+AutoLayout.swift
+++ b/Sources/Pageboy/Utilities/Extensions/UIView+AutoLayout.swift
@@ -12,7 +12,15 @@ internal extension UIView {
     
     @discardableResult
     func pinToSuperviewEdges(priority: UILayoutPriority = .required) -> [NSLayoutConstraint] {
-        let superview = guardForSuperview()
+        guard let superview = guardForSuperview() else {
+            #if DEBUG
+            fatalError("Could not fetch superview in pinToSuperviewEdges")
+            #else
+            return [NSLayoutConstraint]()
+            #endif
+        }
+
+
         
         return addConstraints(priority: priority, { () -> [NSLayoutConstraint] in
             return [
@@ -38,14 +46,18 @@ internal extension UIView {
         })
         
         guard let constraint = constraints.first else {
+            #if DEBUG
             fatalError("Could not add matchWidth constraint")
+            #else
+            return nil
+            #endif
         }
         return constraint
     }
     
     @discardableResult
     func matchHeight(to view: UIView,
-                     priority: UILayoutPriority = .required) -> NSLayoutConstraint {
+                     priority: UILayoutPriority = .required) -> NSLayoutConstraint? {
         let constraints = addConstraints(priority: priority, { () -> [NSLayoutConstraint] in
             return [NSLayoutConstraint(item: self,
                                        attribute: .height,
@@ -57,7 +69,11 @@ internal extension UIView {
         })
         
         guard let constraint = constraints.first else {
+            #if DEBUG
             fatalError("Could not add matchHeight constraint")
+            #else
+            return nil
+            #endif
         }
         return constraint
     }
@@ -79,9 +95,13 @@ internal extension UIView {
         return constraints
     }
     
-    private func guardForSuperview() -> UIView {
+    private func guardForSuperview() -> UIView? {
         guard let superview = superview else {
+            #if DEBUG
             fatalError("No superview for view \(self)")
+            #else
+            return nil
+            #endif
         }
         return superview
     }

--- a/Sources/Pageboy/Utilities/Extensions/UIView+Localization.swift
+++ b/Sources/Pageboy/Utilities/Extensions/UIView+Localization.swift
@@ -27,5 +27,5 @@ extension UIView {
         assert(Thread.isMainThread)
         return UIView.userInterfaceLayoutDirection(for: semanticContentAttribute)
     }
-    
+
 }


### PR DESCRIPTION
Decided to take a crack at fixing #153 and ended up poking around a bit more than I planned. Key points for this PR:

- Move all FatalErrors to #DEBUG only, as it should not be done in release/prod code. Hard crashing like this will, AFAIK, break people's crash reporting/make crashes seem random.

- let self=self aliasing is a compiler bug and will be removed in future swift versions, might as well fix now and use a guard inside weak self closures for cleaning up optional chaining.

- Main thread safety: More enforcement of main thread usage for functions that manipulate UIKit classes. Conversion involved adding asserts, making current functions private and adding a public function that thread casts the private function to main.

- Closure Captures: Generally closures should capture their inputs (especially if they're classes/reference types) to prevent memory/BAD_ACCESS errors when/if things get changed out from under you. ViewControllers are, in my experience, particularly nasty about this so closure captures help a ton.

Thanks again for an awesome library! It looks like all tests are passing and I'll run this fork in through our QA/production and report back over the next week if any unexpected issues occur