### PR TITLE
'public' modifier is redundant for * declared in a public extension

### DIFF
--- a/Sources/Pageboy/Model/NavigationDirection.swift
+++ b/Sources/Pageboy/Model/NavigationDirection.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public extension PageboyViewController {
  
-    public enum NavigationDirection {
+    enum NavigationDirection {
         case neutral
         case forward
         case reverse

--- a/Sources/Pageboy/Model/Page.swift
+++ b/Sources/Pageboy/Model/Page.swift
@@ -11,7 +11,7 @@ import Foundation
 public extension PageboyViewController {
  
     /// A page index.
-    public typealias PageIndex = Int
+    typealias PageIndex = Int
     
     /// The index of a page in the page view controller.
     ///
@@ -21,7 +21,7 @@ public extension PageboyViewController {
     /// - last: The last page.
     /// - at: A custom specified page index.
     // swiftlint:disable identifier_name
-    public enum Page {
+    enum Page {
         case next
         case previous
         case first

--- a/Sources/Pageboy/PageboyViewController+Management.swift
+++ b/Sources/Pageboy/PageboyViewController+Management.swift
@@ -14,7 +14,7 @@ public extension PageboyViewController {
     /// Reload the view controllers in the page view controller.
     /// This reloads the dataSource entirely, calling viewControllers(forPageboyViewController:)
     /// and defaultPageIndex(forPageboyViewController:).
-    public func reloadData() {
+    func reloadData() {
         reloadData(reloadViewControllers: true)
     }
     
@@ -181,7 +181,7 @@ internal extension PageboyViewController {
     /// Set up inner UIPageViewController ready for displaying pages.
     ///
     /// - Parameter reloadViewControllers: Reload the view controllers data source for the PageboyViewController.
-    internal func setUpPageViewController(reloadViewControllers: Bool = true) {
+    func setUpPageViewController(reloadViewControllers: Bool = true) {
         let existingZIndex: Int?
         if let pageViewController = self.pageViewController { // destroy existing page VC
             existingZIndex = view.subviews.index(of: pageViewController.view)
@@ -239,7 +239,7 @@ internal extension PageboyViewController {
     }
     
     /// Re-initialize the internal UIPageViewController instance without reloading data source if it currently exists.
-    internal func reconfigurePageViewController() {
+    func reconfigurePageViewController() {
         guard pageViewController != nil else {
             return
         }
@@ -248,7 +248,7 @@ internal extension PageboyViewController {
     
     #if swift(>=4.2)
     /// The options to be passed to a UIPageViewController instance.
-    internal var pageViewControllerOptions: [UIPageViewController.OptionsKey: Any]? {
+    var pageViewControllerOptions: [UIPageViewController.OptionsKey: Any]? {
         var options = [UIPageViewController.OptionsKey: Any]()
         
         if interPageSpacing > 0.0 {
@@ -262,7 +262,7 @@ internal extension PageboyViewController {
     }
     #else
     /// The options to be passed to a UIPageViewController instance.
-    internal var pageViewControllerOptions: [String: Any]? {
+    var pageViewControllerOptions: [String: Any]? {
         var options = [String: Any]()
         
         if interPageSpacing > 0.0 {

--- a/Sources/Pageboy/PageboyViewController+Updating.swift
+++ b/Sources/Pageboy/PageboyViewController+Updating.swift
@@ -15,7 +15,7 @@ public extension PageboyViewController {
     /// - doNothing: Do nothing.
     /// - scrollToUpdate: Scroll to the update.
     /// - scrollTo: Scroll to a specified index.
-    public enum PageUpdateBehavior {
+    enum PageUpdateBehavior {
         case doNothing
         case scrollToUpdate
         case scrollTo(index: PageIndex)

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -303,9 +303,9 @@ public extension PageboyViewController {
     /// - parameter completion: The completion closure.
     /// - Returns: Whether the scroll was executed.
     @discardableResult
-    public func scrollToPage(_ page: Page,
-                             animated: Bool,
-                             completion: PageScrollCompletion? = nil) -> Bool {
+    func scrollToPage(_ page: Page,
+                      animated: Bool,
+                      completion: PageScrollCompletion? = nil) -> Bool {
         var result: Bool = false
         DispatchQueue.executeInMainThread {
             result = self._scrollToPage(page,

--- a/Sources/Pageboy/Transitioning/PageboyViewController+Transitioning.swift
+++ b/Sources/Pageboy/Transitioning/PageboyViewController+Transitioning.swift
@@ -12,7 +12,7 @@ import UIKit
 public extension PageboyViewController {
     
     /// Transition for a page scroll.
-    public final class Transition {
+    final class Transition {
         
         /// Style for the transition.
         ///
@@ -85,11 +85,11 @@ internal extension PageboyViewController {
     ///   - direction: The direction of travel.
     ///   - animated: Whether to animate the transition.
     ///   - completion: Action on the completion of the transition.
-    internal func performTransition(from startIndex: Int,
-                                    to endIndex: Int,
-                                    with direction: NavigationDirection,
-                                    animated: Bool,
-                                    completion: @escaping TransitionOperation.Completion) {
+    func performTransition(from startIndex: Int,
+                           to endIndex: Int,
+                           with direction: NavigationDirection,
+                           animated: Bool,
+                           completion: @escaping TransitionOperation.Completion) {
 
         guard let transition = transition, animated == true, activeTransitionOperation == nil else {
                 completion(false)

--- a/Sources/Pageboy/UIViewController+Pageboy.swift
+++ b/Sources/Pageboy/UIViewController+Pageboy.swift
@@ -12,7 +12,7 @@ public extension UIViewController {
     
     /// The parent PageboyViewController.
     /// Available from any direct child view controllers within a PageboyViewController.
-    public var parentPageboy: PageboyViewController? {
+    var parentPageboy: PageboyViewController? {
         return parent?.parent as? PageboyViewController
     }
 }


### PR DESCRIPTION
Quite annoying to have all those Xcode warnings when using PageBoy.

<img width="522" alt="screen shot 2019-02-22 at 10 07 56" src="https://user-images.githubusercontent.com/839992/53215288-f5e01180-368a-11e9-97ac-1f299d92e93a.png">
