### PR TITLE
Fix issue where index map could have invalid keys

### DIFF
--- a/Sources/Pageboy.xcodeproj/project.pbxproj
+++ b/Sources/Pageboy.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		460906B7222A785E005474BF /* WeakContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460906B6222A785E005474BF /* WeakContainer.swift */; };
-		460906B9222A79F6005474BF /* ObjectIndexMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460906B8222A79F6005474BF /* ObjectIndexMap.swift */; };
+		460906B9222A79F6005474BF /* IndexedObjectMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460906B8222A79F6005474BF /* IndexedObjectMap.swift */; };
 		461D6DF1201795A100E0CDEE /* UIScrollView+ScrollActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461D6DF0201795A100E0CDEE /* UIScrollView+ScrollActivity.swift */; };
 		461D6DF2201795A100E0CDEE /* UIScrollView+ScrollActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461D6DF0201795A100E0CDEE /* UIScrollView+ScrollActivity.swift */; };
 		462A65DD2000FCAA0051C79C /* UIView+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462A65D92000FCAA0051C79C /* UIView+Localization.swift */; };
@@ -79,7 +79,7 @@
 
 /* Begin PBXFileReference section */
 		460906B6222A785E005474BF /* WeakContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakContainer.swift; sourceTree = "<group>"; };
-		460906B8222A79F6005474BF /* ObjectIndexMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectIndexMap.swift; sourceTree = "<group>"; };
+		460906B8222A79F6005474BF /* IndexedObjectMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexedObjectMap.swift; sourceTree = "<group>"; };
 		461D6DF0201795A100E0CDEE /* UIScrollView+ScrollActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+ScrollActivity.swift"; sourceTree = "<group>"; };
 		462A65D92000FCAA0051C79C /* UIView+Localization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Localization.swift"; sourceTree = "<group>"; };
 		462A65DA2000FCAA0051C79C /* UIView+AutoLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+AutoLayout.swift"; sourceTree = "<group>"; };
@@ -277,7 +277,7 @@
 			children = (
 				462A65D82000FCAA0051C79C /* Extensions */,
 				460906B6222A785E005474BF /* WeakContainer.swift */,
-				460906B8222A79F6005474BF /* ObjectIndexMap.swift */,
+				460906B8222A79F6005474BF /* IndexedObjectMap.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -492,7 +492,7 @@
 				464ADF552097565D00929AFB /* Page.swift in Sources */,
 				46ADAAB8208F7E1500974529 /* PageboyViewController+AutoScrolling.swift in Sources */,
 				462A65E32000FCAA0051C79C /* UIPageViewController+ScrollView.swift in Sources */,
-				460906B9222A79F6005474BF /* ObjectIndexMap.swift in Sources */,
+				460906B9222A79F6005474BF /* IndexedObjectMap.swift in Sources */,
 				46ADAAC2208F7E8500974529 /* TransitionOperation.swift in Sources */,
 				461D6DF1201795A100E0CDEE /* UIScrollView+ScrollActivity.swift in Sources */,
 				462A65DF2000FCAA0051C79C /* UIView+AutoLayout.swift in Sources */,

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -138,7 +138,7 @@ open class PageboyViewController: UIViewController {
     /// The number of view controllers in the page view controller.
     internal var viewControllerCount: Int?
     /// A map of view controllers and related page indexes.
-    internal lazy var viewControllerIndexMap = ObjectIndexMap<UIViewController>()
+    internal lazy var viewControllerIndexMap = IndexedObjectMap<UIViewController>()
     
     /// The number of pages in the page view controller.
     public var pageCount: Int? {

--- a/Sources/Pageboy/Utilities/IndexedObjectMap.swift
+++ b/Sources/Pageboy/Utilities/IndexedObjectMap.swift
@@ -29,8 +29,6 @@ internal final class IndexedObjectMap<T: AnyObject> {
 
         let wrapper = WeakWrapper<T>(object)
         map[index] = wrapper
-        
-        print(self.map)
     }
     
     func removeAll() {

--- a/Sources/Pageboy/Utilities/IndexedObjectMap.swift
+++ b/Sources/Pageboy/Utilities/IndexedObjectMap.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-/// Map which stores an index next to an object.
-internal final class ObjectIndexMap<T: AnyObject> {
+/// Map which weakly stores an object for an index key.
+internal final class IndexedObjectMap<T: AnyObject> {
     
     // MARK: Properties
     

--- a/Sources/Pageboy/Utilities/ObjectIndexMap.swift
+++ b/Sources/Pageboy/Utilities/ObjectIndexMap.swift
@@ -13,13 +13,13 @@ internal final class ObjectIndexMap<T: AnyObject> {
     
     // MARK: Properties
     
-    private var map = [WeakWrapper<T>: Int]()
+    private var map = [Int: WeakWrapper<T>]()
     
     // MARK: Accessors
     
     func index(for object: T) -> Int? {
         cleanUp()
-        return map.first(where: { $0.key.object === object })?.value
+        return map.first(where: { $0.value.object === object })?.key
     }
  
     // MARK: Mutators
@@ -28,7 +28,9 @@ internal final class ObjectIndexMap<T: AnyObject> {
         cleanUp()
 
         let wrapper = WeakWrapper<T>(object)
-        map[wrapper] = index
+        map[index] = wrapper
+        
+        print(self.map)
     }
     
     func removeAll() {
@@ -36,12 +38,12 @@ internal final class ObjectIndexMap<T: AnyObject> {
     }
     
     private func cleanUp() {
-        var invalidObjects = [WeakWrapper<T>]()
+        var invalidIndexes = [Int]()
         map.forEach({
-            if $0.key.object == nil {
-                invalidObjects.append($0.key)
+            if $0.value.object == nil {
+                invalidIndexes.append($0.key)
             }
         })
-        invalidObjects.forEach({ self.map[$0] = nil })
+        invalidIndexes.forEach({ self.map[$0] = nil })
     }
 }

--- a/Sources/Pageboy/Utilities/WeakContainer.swift
+++ b/Sources/Pageboy/Utilities/WeakContainer.swift
@@ -11,20 +11,15 @@ import Foundation
 internal final class WeakWrapper<T: AnyObject> {
     
     private(set) weak var object: T?
-    private let uuid = UUID().uuidString
     
     init(_ object: T) {
         self.object = object
     }
 }
 
-extension WeakWrapper: Hashable {
+extension WeakWrapper: Equatable {
     
     static func == (lhs: WeakWrapper, rhs: WeakWrapper) -> Bool {
         return lhs.object === rhs.object
-    }
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(uuid.hashValue)
     }
 }


### PR DESCRIPTION
Fix for #198 caused issues with invalid keys in map. Changed so that the map is keyed by page indexes rather than the object (view controller)