### PR TITLE
deprecated value can only be used for iOS or tvOS version

### DIFF
--- a/Sources/Pageboy/UIViewController+Pageboy.swift
+++ b/Sources/Pageboy/UIViewController+Pageboy.swift
@@ -12,7 +12,8 @@ extension UIViewController {
     
     /// The parent PageboyViewController.
     /// Available from any direct child view controllers within a PageboyViewController.
-    @available(*, deprecated: 3.1.0, message: "Use pageboyParent")
+    /// Deprecated in Pageboy 3.1.0.
+    @available(*, deprecated, message: "Use pageboyParent")
     public var parentPageboy: PageboyViewController? {
         return pageboyParent
     }


### PR DESCRIPTION
This commit fixes an Xcode 10.2 warning.