### PR TITLE
Add default value ( nil ) for Pageboy default page datasource

### DIFF
--- a/Example/Pageboy-Example/PageViewController.swift
+++ b/Example/Pageboy-Example/PageViewController.swift
@@ -93,10 +93,6 @@ extension PageViewController: PageboyViewControllerDataSource {
                         at index: PageboyViewController.PageIndex) -> UIViewController? {
         return viewControllers[index]
     }
-    
-    func defaultPage(for pageboyViewController: PageboyViewController) -> PageboyViewController.Page? {
-        return nil
-    }
 }
 
 // MARK: PageboyViewControllerDelegate

--- a/Sources/Pageboy/Protocols/PageboyViewControllerDataSource.swift
+++ b/Sources/Pageboy/Protocols/PageboyViewControllerDataSource.swift
@@ -31,3 +31,9 @@ public protocol PageboyViewControllerDataSource: class {
     /// - Returns: Default page
     func defaultPage(for pageboyViewController: PageboyViewController) -> PageboyViewController.Page?
 }
+
+public extension PageboyViewControllerDataSource {
+    func defaultPage(for pageboyViewController: PageboyViewController) -> PageboyViewController.Page? {
+        return nil
+    }
+}


### PR DESCRIPTION
It seems to me that for most people, they will return nil as a default page, so I was thinking how about doing that for them?

For other people who are using a default page, they will not notice the difference.

What do you think?