### PR TITLE
SwiftLint warning: Adding weak to a computed property has no effect.

### DIFF
--- a/Sources/Pageboy/PageboyViewController+Management.swift
+++ b/Sources/Pageboy/PageboyViewController+Management.swift
@@ -255,7 +255,7 @@ internal extension PageboyViewController {
             options[.interPageSpacing] = interPageSpacing
         }
         
-        guard options.count > 0 else {
+        guard !options.isEmpty else {
             return nil
         }
         return options
@@ -269,7 +269,7 @@ internal extension PageboyViewController {
             options[UIPageViewControllerOptionInterPageSpacingKey] = interPageSpacing
         }
         
-        guard options.count > 0 else {
+        guard !options.isEmpty else {
             return nil
         }
         return options

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -160,7 +160,7 @@ open class PageboyViewController: UIViewController {
     /// The relative page position that the page view controller is currently at.
     public internal(set) var currentPosition: CGPoint?
     /// The view controller that the page view controller is currently at.
-    public weak var currentViewController: UIViewController? {
+    public var currentViewController: UIViewController? {
         guard let currentIndex = currentIndex,
             viewControllerCount ?? 0 > currentIndex else {
                 return nil


### PR DESCRIPTION
Also fixes another SwiftLint warning, the one for `empty_count` (I know you've disabled it, but it's still better practice to use `isEmpty`).