### PR TITLE
Documenting that only .horizontal and .vertical are supported. (solves an Xcode warning for additional unknown values)

### DIFF
--- a/Sources/Pageboy/PageboyViewController+ScrollCalculations.swift
+++ b/Sources/Pageboy/PageboyViewController+ScrollCalculations.swift
@@ -48,7 +48,8 @@ internal extension PageboyViewController {
     func calculateRelativePageSizeAndContentOffset(for scrollView: UIScrollView) -> (CGFloat, CGFloat) {
         var pageSize: CGFloat
         var contentOffset: CGFloat
-        switch navigationOrientation {
+        let orientation = navigationOrientation
+        switch orientation {
             
         case .horizontal:
             pageSize = scrollView.frame.size.width
@@ -61,6 +62,9 @@ internal extension PageboyViewController {
         case .vertical:
             pageSize = scrollView.frame.size.height
             contentOffset = scrollView.contentOffset.y
+            
+        @unknown default:
+            fatalError("unsupported orientation \(orientation.rawValue)")
         }
         
         return (pageSize, contentOffset)

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -25,7 +25,12 @@ open class PageboyViewController: UIViewController {
     internal var expectedTransitionIndex: PageIndex?
 
     /// The orientation that the page view controller transitions on.
+    ///
+    /// Supported values are .horizontal and .vertical.
     public var navigationOrientation: UIPageViewController.NavigationOrientation = .horizontal {
+        willSet {
+            assert(newValue == .horizontal || newValue == .vertical, "unsupported navigationOrientation \(newValue.rawValue)")
+        }
         didSet {
             reconfigurePageViewController()
         }

--- a/Sources/Pageboy/Transitioning/PageboyViewController+Transitioning.swift
+++ b/Sources/Pageboy/Transitioning/PageboyViewController+Transitioning.swift
@@ -105,6 +105,8 @@ internal extension PageboyViewController {
 
         prepareForTransition()
 
+        let navigationOrientation = self.navigationOrientation
+
         /// Calculate semantic direction for RtL languages
         var semanticDirection = direction
         if view.layoutIsRightToLeft && navigationOrientation == .horizontal {

--- a/Sources/Pageboy/Transitioning/TransitionOperation+Action.swift
+++ b/Sources/Pageboy/Transitioning/TransitionOperation+Action.swift
@@ -52,6 +52,9 @@ internal extension TransitionOperation.Action {
             default:
                 return .fromTop
             }
+            
+        @unknown default:
+            fatalError("unsupported orientation \(orientation.rawValue)")
         }
     }
     #else


### PR DESCRIPTION
navigationOrientation is an Objective-C enum, so it's easy to pass an arbitrary integer value and there is an Xcode warning for that.

This pull request does:
- document and assert that only .horizontal and .vertical can be used for `navigationOrientation`
- solves the Xcode warnings by adding `@unknown default:`
- declare `let navigationOrientation = self.navigationOrientation` to avoid multiple accesses to the same getter (and potential threading issues)