### PR TITLE
Adds abortScrollToPage delegate

### DIFF
--- a/Example/Pageboy-Example/PageViewController.swift
+++ b/Example/Pageboy-Example/PageViewController.swift
@@ -111,8 +111,10 @@ extension PageViewController: PageboyViewControllerDelegate {
 //        print("willScrollToPageAtIndex: \(index)")
     }
     
-    func pageboyViewController(_ pageboyViewController: PageboyViewController, abortScrollToPageAt index: PageboyViewController.PageIndex, returnToPageAt previousIndex: PageboyViewController.PageIndex) {
-        print("abortScrollToPageAt: \(index), returnToPageAt: \(previousIndex)")
+    func pageboyViewController(_ pageboyViewController: PageboyViewController,
+                               didCancelScrollToPageAt index: PageboyViewController.PageIndex,
+                               returnToPageAt previousIndex: PageboyViewController.PageIndex) {
+//        print("didCancelScrollToPageAt: \(index), returnToPageAt: \(previousIndex)")
     }
     
     func pageboyViewController(_ pageboyViewController: PageboyViewController,

--- a/Example/Pageboy-Example/PageViewController.swift
+++ b/Example/Pageboy-Example/PageViewController.swift
@@ -104,12 +104,15 @@ extension PageViewController: PageboyViewControllerDataSource {
 
 // MARK: PageboyViewControllerDelegate
 extension PageViewController: PageboyViewControllerDelegate {
-    
     func pageboyViewController(_ pageboyViewController: PageboyViewController,
                                willScrollToPageAt index: PageboyViewController.PageIndex,
                                direction: PageboyViewController.NavigationDirection,
                                animated: Bool) {
 //        print("willScrollToPageAtIndex: \(index)")
+    }
+    
+    func pageboyViewController(_ pageboyViewController: PageboyViewController, abortScrollToPageAt index: PageboyViewController.PageIndex, returnToPageAt previousIndex: PageboyViewController.PageIndex) {
+        print("abortScrollToPageAt: \(index), returnToPageAt: \(previousIndex)")
     }
     
     func pageboyViewController(_ pageboyViewController: PageboyViewController,

--- a/Sources/Pageboy/PageboyViewController+ScrollDetection.swift
+++ b/Sources/Pageboy/PageboyViewController+ScrollDetection.swift
@@ -61,7 +61,7 @@ extension PageboyViewController: UIPageViewControllerDelegate {
             }
             
             delegate?.pageboyViewController(self,
-                                            abortScrollToPageAt: expectedIndex,
+                                            didCancelScrollToPageAt: expectedIndex,
                                             returnToPageAt: previousIndex)
             return }
         

--- a/Sources/Pageboy/PageboyViewController+ScrollDetection.swift
+++ b/Sources/Pageboy/PageboyViewController+ScrollDetection.swift
@@ -48,17 +48,29 @@ extension PageboyViewController: UIPageViewControllerDelegate {
                                    didFinishAnimating finished: Bool,
                                    previousViewControllers: [UIViewController],
                                    transitionCompleted completed: Bool) {
-        guard pageViewControllerIsActual(pageViewController), completed else {
+        guard pageViewControllerIsActual(pageViewController) else {
+            return }
+                
+        guard completed else {
+            guard let expectedIndex = expectedTransitionIndex else {
+                return }
+            
+            guard let viewController = previousViewControllers.first,
+                let previousIndex = viewControllerIndexMap.index(for: viewController) else {
+                    return
+            }
+            
+            delegate?.pageboyViewController(self,
+                                            abortScrollToPageAt: expectedIndex,
+                                            returnToPageAt: previousIndex)
             return }
         
-        if let viewController = pageViewController.viewControllers?.first,
-            let index = viewControllerIndexMap.index(for: viewController) {
-            guard index == expectedTransitionIndex else {
-                return
-            }
+        guard let viewController = pageViewController.viewControllers?.first,
+            let index = viewControllerIndexMap.index(for: viewController),
+            index == expectedTransitionIndex else {
+            return }
 
-            updateCurrentPageIndexIfNeeded(index)
-        }
+        updateCurrentPageIndexIfNeeded(index)
     }
 }
 

--- a/Sources/Pageboy/Protocols/PageboyViewControllerDelegate.swift
+++ b/Sources/Pageboy/Protocols/PageboyViewControllerDelegate.swift
@@ -66,3 +66,11 @@ public protocol PageboyViewControllerDelegate: class {
                                didReloadWith currentViewController: UIViewController,
                                currentPageIndex: PageboyViewController.PageIndex)
 }
+
+public extension PageboyViewControllerDelegate {
+    func pageboyViewController(_ pageboyViewController: PageboyViewController,
+                               didCancelScrollToPageAt index: PageboyViewController.PageIndex,
+                               returnToPageAt previousIndex: PageboyViewController.PageIndex) {
+        // Default implementation
+    }
+}

--- a/Sources/Pageboy/Protocols/PageboyViewControllerDelegate.swift
+++ b/Sources/Pageboy/Protocols/PageboyViewControllerDelegate.swift
@@ -41,7 +41,7 @@ public protocol PageboyViewControllerDelegate: class {
     ///   - index: The expected new page index, that was not (!) scrolled to.
     ///   - previousIndex: The page index returned to.
     func pageboyViewController(_ pageboyViewController: PageboyViewController,
-                               abortScrollToPageAt index: PageboyViewController.PageIndex,
+                               didCancelScrollToPageAt index: PageboyViewController.PageIndex,
                                returnToPageAt previousIndex: PageboyViewController.PageIndex)
     
     /// The page view controller did complete scroll to a new page.

--- a/Sources/Pageboy/Protocols/PageboyViewControllerDelegate.swift
+++ b/Sources/Pageboy/Protocols/PageboyViewControllerDelegate.swift
@@ -33,6 +33,16 @@ public protocol PageboyViewControllerDelegate: class {
                                didScrollTo position: CGPoint,
                                direction: PageboyViewController.NavigationDirection,
                                animated: Bool)
+
+    /// The page view controller did not (!) complete scroll to a new page.
+    ///
+    /// - Parameters:
+    ///   - pageboyViewController: The Page view controller.
+    ///   - index: The expected new page index, that was not (!) scrolled to.
+    ///   - previousIndex: The page index returned to.
+    func pageboyViewController(_ pageboyViewController: PageboyViewController,
+                               abortScrollToPageAt index: PageboyViewController.PageIndex,
+                               returnToPageAt previousIndex: PageboyViewController.PageIndex)
     
     /// The page view controller did complete scroll to a new page.
     ///


### PR DESCRIPTION
I added a new call to the Pageboy delegate: It handles aborted scrolling attempts. If there's need for a default implementation for this delegate (so this change doesn't brake any existing implementation) I could add this as well.

Motivation: As already discussed in #181 we need to know if a page transition was aborted or completed. Took as nearly one (1) year 🙄