### PR TITLE
Excludes header file from sources

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,9 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Pageboy",
-            path: ".",
-            sources: ["Sources/Pageboy"]),
+            path: "Sources/Pageboy",
+            exclude: ["Pageboy.h"]
+        ),
         .testTarget(
             name: "PageboyTests",
             dependencies: ["Pageboy"]


### PR DESCRIPTION
This prevents the mixed language error when adding the package via SwiftPM.