### PR TITLE
Fix issues with dynamic insertion + removal

### DIFF
--- a/Sources/Pageboy.xcodeproj/project.pbxproj
+++ b/Sources/Pageboy.xcodeproj/project.pbxproj
@@ -9,8 +9,8 @@
 /* Begin PBXBuildFile section */
 		460906B7222A785E005474BF /* WeakContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460906B6222A785E005474BF /* WeakContainer.swift */; };
 		460906B9222A79F6005474BF /* IndexedObjectMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460906B8222A79F6005474BF /* IndexedObjectMap.swift */; };
-		461D6DF1201795A100E0CDEE /* UIScrollView+ScrollActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461D6DF0201795A100E0CDEE /* UIScrollView+ScrollActivity.swift */; };
-		461D6DF2201795A100E0CDEE /* UIScrollView+ScrollActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461D6DF0201795A100E0CDEE /* UIScrollView+ScrollActivity.swift */; };
+		461D6DF1201795A100E0CDEE /* UIScrollView+Interaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461D6DF0201795A100E0CDEE /* UIScrollView+Interaction.swift */; };
+		461D6DF2201795A100E0CDEE /* UIScrollView+Interaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461D6DF0201795A100E0CDEE /* UIScrollView+Interaction.swift */; };
 		462A65DD2000FCAA0051C79C /* UIView+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462A65D92000FCAA0051C79C /* UIView+Localization.swift */; };
 		462A65DE2000FCAA0051C79C /* UIView+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462A65D92000FCAA0051C79C /* UIView+Localization.swift */; };
 		462A65DF2000FCAA0051C79C /* UIView+AutoLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462A65DA2000FCAA0051C79C /* UIView+AutoLayout.swift */; };
@@ -85,7 +85,7 @@
 /* Begin PBXFileReference section */
 		460906B6222A785E005474BF /* WeakContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakContainer.swift; sourceTree = "<group>"; };
 		460906B8222A79F6005474BF /* IndexedObjectMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexedObjectMap.swift; sourceTree = "<group>"; };
-		461D6DF0201795A100E0CDEE /* UIScrollView+ScrollActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+ScrollActivity.swift"; sourceTree = "<group>"; };
+		461D6DF0201795A100E0CDEE /* UIScrollView+Interaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Interaction.swift"; sourceTree = "<group>"; };
 		462A65D92000FCAA0051C79C /* UIView+Localization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Localization.swift"; sourceTree = "<group>"; };
 		462A65DA2000FCAA0051C79C /* UIView+AutoLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+AutoLayout.swift"; sourceTree = "<group>"; };
 		462A65DB2000FCAA0051C79C /* UIApplication+SafeShared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+SafeShared.swift"; sourceTree = "<group>"; };
@@ -160,7 +160,7 @@
 				462A65DA2000FCAA0051C79C /* UIView+AutoLayout.swift */,
 				462A65DB2000FCAA0051C79C /* UIApplication+SafeShared.swift */,
 				462A65DC2000FCAA0051C79C /* UIPageViewController+ScrollView.swift */,
-				461D6DF0201795A100E0CDEE /* UIScrollView+ScrollActivity.swift */,
+				461D6DF0201795A100E0CDEE /* UIScrollView+Interaction.swift */,
 				462D03DE2091D3AB0033C710 /* UIView+Animation.swift */,
 				BB5277382211308B003695BB /* DispatchQueue+main.swift */,
 			);
@@ -502,7 +502,7 @@
 				462A65E32000FCAA0051C79C /* UIPageViewController+ScrollView.swift in Sources */,
 				460906B9222A79F6005474BF /* IndexedObjectMap.swift in Sources */,
 				46ADAAC2208F7E8500974529 /* TransitionOperation.swift in Sources */,
-				461D6DF1201795A100E0CDEE /* UIScrollView+ScrollActivity.swift in Sources */,
+				461D6DF1201795A100E0CDEE /* UIScrollView+Interaction.swift in Sources */,
 				462A65DF2000FCAA0051C79C /* UIView+AutoLayout.swift in Sources */,
 				46ADAAC8208F7EB200974529 /* PageboyViewController+Updating.swift in Sources */,
 				BB5277392211308B003695BB /* DispatchQueue+main.swift in Sources */,
@@ -550,7 +550,7 @@
 				464ADF562097565D00929AFB /* Page.swift in Sources */,
 				46ADAAB9208F7E1500974529 /* PageboyViewController+AutoScrolling.swift in Sources */,
 				462A65E42000FCAA0051C79C /* UIPageViewController+ScrollView.swift in Sources */,
-				461D6DF2201795A100E0CDEE /* UIScrollView+ScrollActivity.swift in Sources */,
+				461D6DF2201795A100E0CDEE /* UIScrollView+Interaction.swift in Sources */,
 				46ADAAC3208F7E8500974529 /* TransitionOperation.swift in Sources */,
 				462A65E02000FCAA0051C79C /* UIView+AutoLayout.swift in Sources */,
 				46ADAAC9208F7EB200974529 /* PageboyViewController+Updating.swift in Sources */,

--- a/Sources/Pageboy/PageboyViewController+Updating.swift
+++ b/Sources/Pageboy/PageboyViewController+Updating.swift
@@ -33,13 +33,14 @@ internal extension PageboyViewController {
     func performUpdates(for newIndex: PageIndex?,
                         viewController: UIViewController?,
                         update: (operation: UpdateOperation, behavior: PageUpdateBehavior),
-                        indexOperation: (_ currentIndex: PageIndex, _ newIndex: PageIndex) -> Void) {
+                        indexOperation: (_ currentIndex: PageIndex, _ newIndex: PageIndex) -> Void,
+                        completion: ((Bool) -> Void)?) {
         guard let newIndex = newIndex, let viewController = viewController else { // no view controller - reset
             updateViewControllers(to: [UIViewController()],
                                   animated: false,
                                   async: false,
                                   force: false,
-                                  completion: nil)
+                                  completion: completion)
             self.currentIndex = nil
             return
         }
@@ -49,7 +50,7 @@ internal extension PageboyViewController {
                                   animated: false,
                                   async: false,
                                   force: false,
-                                  completion: nil)
+                                  completion: completion)
             self.currentIndex = newIndex
             return
         }
@@ -64,7 +65,7 @@ internal extension PageboyViewController {
                                             animated: false,
                                             async: true,
                                             force: false,
-                                            completion: nil)
+                                            completion: completion)
             })
         } else { // update is happening on some other page.
             indexOperation(currentIndex, newIndex)
@@ -72,6 +73,7 @@ internal extension PageboyViewController {
             // If we are deleting, check if the new index is greater than the current. If it is then we
             // dont need to do anything...
             if update.operation == .delete && newIndex > currentIndex {
+                completion?(true)
                 return
             }
             
@@ -83,6 +85,7 @@ internal extension PageboyViewController {
                     
                 case .insert:
                     guard let currentViewController = currentViewController else {
+                        completion?(true)
                         return
                     }
                     newViewController = currentViewController
@@ -93,9 +96,11 @@ internal extension PageboyViewController {
                 
                 updateViewControllers(to: [newViewController], animated: false, async: true, force: false, completion: { [weak self, newIndex, update] _ in
                     self?.performScrollUpdate(to: newIndex, behavior: update.behavior)
+                    completion?(true)
                 })
             } else { // Otherwise just perform scroll update
                 performScrollUpdate(to: newIndex, behavior: update.behavior)
+                completion?(true)
             }
         }
     }

--- a/Sources/Pageboy/PageboyViewController+Updating.swift
+++ b/Sources/Pageboy/PageboyViewController+Updating.swift
@@ -32,8 +32,7 @@ internal extension PageboyViewController {
     
     func performUpdates(for newIndex: PageIndex?,
                         viewController: UIViewController?,
-                        operation: UpdateOperation,
-                        updateBehavior: PageUpdateBehavior,
+                        update: (operation: UpdateOperation, behavior: PageUpdateBehavior),
                         indexOperation: (_ currentIndex: PageIndex, _ newIndex: PageIndex) -> Void) {
         guard let newIndex = newIndex, let viewController = viewController else { // no view controller - reset
             updateViewControllers(to: [UIViewController()],
@@ -57,7 +56,7 @@ internal extension PageboyViewController {
         
         // If we are inserting a page that is lower/equal to the current index
         // we have to move the current page up therefore we can't just cross-dissolve.
-        let isInsertionThatRequiresMoving = operation == .insert && newIndex <= currentIndex
+        let isInsertionThatRequiresMoving = update.operation == .insert && newIndex <= currentIndex
         
         if !isInsertionThatRequiresMoving && newIndex == currentIndex { // currently on the page for the update.
             pageViewController?.view.crossDissolve(during: { [weak self, viewController] in
@@ -72,7 +71,7 @@ internal extension PageboyViewController {
             
             // If we are deleting, check if the new index is greater than the current. If it is then we
             // dont need to do anything...
-            if operation == .delete && newIndex > currentIndex {
+            if update.operation == .delete && newIndex > currentIndex {
                 return
             }
             
@@ -80,7 +79,7 @@ internal extension PageboyViewController {
             if pageIndex(newIndex, isNextTo: currentIndex) {
                 
                 let newViewController: UIViewController
-                switch operation {
+                switch update.operation {
                     
                 case .insert:
                     guard let currentViewController = currentViewController else {
@@ -92,11 +91,11 @@ internal extension PageboyViewController {
                     newViewController = viewController
                 }
                 
-                updateViewControllers(to: [newViewController], animated: false, async: true, force: false, completion: { [weak self, newIndex, updateBehavior] _ in
-                    self?.performScrollUpdate(to: newIndex, behavior: updateBehavior)
+                updateViewControllers(to: [newViewController], animated: false, async: true, force: false, completion: { [weak self, newIndex, update] _ in
+                    self?.performScrollUpdate(to: newIndex, behavior: update.behavior)
                 })
             } else { // Otherwise just perform scroll update
-                performScrollUpdate(to: newIndex, behavior: updateBehavior)
+                performScrollUpdate(to: newIndex, behavior: update.behavior)
             }
         }
     }

--- a/Sources/Pageboy/PageboyViewController+Updating.swift
+++ b/Sources/Pageboy/PageboyViewController+Updating.swift
@@ -70,13 +70,29 @@ internal extension PageboyViewController {
         } else { // update is happening on some other page.
             indexOperation(currentIndex, newIndex)
             
+            // If we are deleting, check if the new index is greater than the current. If it is then we
+            // dont need to do anything...
+            if operation == .delete && newIndex > currentIndex {
+                return
+            }
+            
             // Reload current view controller in UIPageViewController if insertion index is next/previous page.
             if pageIndex(newIndex, isNextTo: currentIndex) {
-                guard let currentViewController = currentViewController else {
-                    return
+                
+                let newViewController: UIViewController
+                switch operation {
+                    
+                case .insert:
+                    guard let currentViewController = currentViewController else {
+                        return
+                    }
+                    newViewController = currentViewController
+                    
+                case .delete:
+                    newViewController = viewController
                 }
                 
-                updateViewControllers(to: [currentViewController], animated: false, async: true, force: false, completion: { [weak self, newIndex, updateBehavior] _ in
+                updateViewControllers(to: [newViewController], animated: false, async: true, force: false, completion: { [weak self, newIndex, updateBehavior] _ in
                     self?.performScrollUpdate(to: newIndex, behavior: updateBehavior)
                 })
             } else { // Otherwise just perform scroll update

--- a/Sources/Pageboy/PageboyViewController+Updating.swift
+++ b/Sources/Pageboy/PageboyViewController+Updating.swift
@@ -20,6 +20,11 @@ extension PageboyViewController {
         case scrollToUpdate
         case scrollTo(index: PageIndex)
     }
+    
+    internal enum UpdateOperation {
+        case insert
+        case delete
+    }
 }
 
 // MARK: - Page Updates
@@ -27,6 +32,7 @@ internal extension PageboyViewController {
     
     func performUpdates(for newIndex: PageIndex?,
                         viewController: UIViewController?,
+                        operation: UpdateOperation,
                         updateBehavior: PageUpdateBehavior,
                         indexOperation: (_ currentIndex: PageIndex, _ newIndex: PageIndex) -> Void) {
         guard let newIndex = newIndex, let viewController = viewController else { // no view controller - reset
@@ -49,7 +55,11 @@ internal extension PageboyViewController {
             return
         }
         
-        if newIndex == currentIndex { // currently on the page for the update.
+        // If we are inserting a page that is lower/equal to the current index
+        // we have to move the current page up therefore we can't just cross-dissolve.
+        let isInsertionThatRequiresMoving = operation == .insert && newIndex <= currentIndex
+        
+        if !isInsertionThatRequiresMoving && newIndex == currentIndex { // currently on the page for the update.
             pageViewController?.view.crossDissolve(during: { [weak self, viewController] in
                 self?.updateViewControllers(to: [viewController],
                                             animated: false,

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -290,10 +290,11 @@ open class PageboyViewController: UIViewController {
 
         performUpdates(for: index,
                         viewController: newViewController,
+                        operation: .insert,
                         updateBehavior: updateBehavior,
                         indexOperation: { (index, newIndex) in
 
-                        if index > newIndex {
+                        if index >= newIndex {
                             currentIndex = index + 1
                         }
         })
@@ -330,6 +331,7 @@ open class PageboyViewController: UIViewController {
 
             performUpdates(for: newIndex,
                            viewController: newViewController,
+                           operation: .delete,
                            updateBehavior: updateBehavior,
                            indexOperation: { (index, newIndex) in
 

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -290,8 +290,7 @@ open class PageboyViewController: UIViewController {
 
         performUpdates(for: index,
                         viewController: newViewController,
-                        operation: .insert,
-                        updateBehavior: updateBehavior,
+                        update: (operation: .insert, behavior: updateBehavior),
                         indexOperation: { (index, newIndex) in
 
                         if index >= newIndex {
@@ -331,8 +330,7 @@ open class PageboyViewController: UIViewController {
 
             performUpdates(for: newIndex,
                            viewController: newViewController,
-                           operation: .delete,
-                           updateBehavior: updateBehavior,
+                           update: (operation: .delete, behavior: updateBehavior),
                            indexOperation: { (index, newIndex) in
 
                             if index > newIndex {

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -288,15 +288,17 @@ open class PageboyViewController: UIViewController {
 
             viewControllerCount = newPageCount
             viewControllerIndexMap.removeAll()
-
-            performUpdates(for: index,
-                            viewController: newViewController,
-                            update: (operation: .insert, behavior: updateBehavior),
-                            indexOperation: { (index, newIndex) in
-
+            
+            pageViewController?.scrollView?.cancelTouches()
+            view.isUserInteractionEnabled = false
+            performUpdates(for: index, viewController: newViewController,
+                           update: (operation: .insert, behavior: updateBehavior),
+                           indexOperation: { (index, newIndex) in
                             if index >= newIndex {
                                 currentIndex = index + 1
-                            }
+                            }},
+                           completion: { (_) in
+                            self.view.isUserInteractionEnabled = true
             })
         })
     }
@@ -329,14 +331,16 @@ open class PageboyViewController: UIViewController {
             viewControllerCount = newPageCount
             viewControllerIndexMap.removeAll()
 
-            performUpdates(for: newIndex,
-                           viewController: newViewController,
+            pageViewController?.scrollView?.cancelTouches()
+            view.isUserInteractionEnabled = false
+            performUpdates(for: newIndex, viewController: newViewController,
                            update: (operation: .delete, behavior: updateBehavior),
                            indexOperation: { (index, newIndex) in
-
                             if index > newIndex {
                                 currentIndex = index - 1
-                            }
+                            }},
+                           completion: { (_) in
+                            self.view.isUserInteractionEnabled = true
             })
         })
     }

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -276,28 +276,29 @@ open class PageboyViewController: UIViewController {
     ///   - updateBehavior: Behavior to execute after the page was inserted.
     open func insertPage(at index: PageIndex,
                          then updateBehavior: PageUpdateBehavior = .scrollToUpdate) {
-    verifyNewPageCount(then: { (oldPageCount, newPageCount) in
+        
+        verifyNewPageCount(then: { (oldPageCount, newPageCount) in
         assert(newPageCount > oldPageCount,
-                "Attempt to insert page at \(index) but there are only \(newPageCount) pages after the update")
+                    "Attempt to insert page at \(index) but there are only \(newPageCount) pages after the update")
 
-        guard let newViewController = dataSource?.viewController(for: self, at: index) else {
-            assertionFailure("Expected to find inserted UIViewController at page \(index)")
-            return
-        }
+            guard let newViewController = dataSource?.viewController(for: self, at: index) else {
+                assertionFailure("Expected to find inserted UIViewController at page \(index)")
+                return
+            }
 
-        viewControllerCount = newPageCount
-        viewControllerIndexMap.removeAll()
+            viewControllerCount = newPageCount
+            viewControllerIndexMap.removeAll()
 
-        performUpdates(for: index,
-                        viewController: newViewController,
-                        update: (operation: .insert, behavior: updateBehavior),
-                        indexOperation: { (index, newIndex) in
+            performUpdates(for: index,
+                            viewController: newViewController,
+                            update: (operation: .insert, behavior: updateBehavior),
+                            indexOperation: { (index, newIndex) in
 
-                        if index >= newIndex {
-                            currentIndex = index + 1
-                        }
+                            if index >= newIndex {
+                                currentIndex = index + 1
+                            }
+            })
         })
-    })
     }
     
     /// Delete an existing page from the page view controller.

--- a/Sources/Pageboy/Utilities/Extensions/UIScrollView+Interaction.swift
+++ b/Sources/Pageboy/Utilities/Extensions/UIScrollView+Interaction.swift
@@ -1,5 +1,5 @@
 //
-//  UIScrollView+ScrollActivity.swift
+//  UIScrollView+Interaction.swift
 //  Pageboy
 //
 //  Created by Merrick Sapsford on 23/01/2018.
@@ -13,5 +13,10 @@ internal extension UIScrollView {
     /// Whether the scroll view can be assumed to be interactively scrolling
     var isProbablyActiveInScroll: Bool {
         return isTracking || isDecelerating
+    }
+    
+    func cancelTouches() {
+        panGestureRecognizer.isEnabled = false
+        panGestureRecognizer.isEnabled = true
     }
 }


### PR DESCRIPTION
Fixes a number of issues that were related to the dynamic insertion/deletion logic in `PageboyViewController`.

Specifically:
- Fixes issue where inserting a page at the current index with `doNothing` `PageUpdateBehavior` would display the inserted view controller (Resolves #211)
- Fix issue where deleting a page on an upper index could cause index corruption.
- Fix issue where scroll interaction during updates could cause index corruption (touches are now forcibly cancelled and interaction disabled until updates have completed).