### PR TITLE
Fix infinite scroll bug

### DIFF
--- a/Sources/Pageboy/PageboyViewController+Management.swift
+++ b/Sources/Pageboy/PageboyViewController+Management.swift
@@ -254,7 +254,7 @@ extension PageboyViewController: UIPageViewControllerDataSource {
             return nil
         }
 
-        if let index = currentIndex {
+        if let index = currentIndex, viewControllerCount > 1 {
             if index != 0 {
                 return fetchViewController(at: index - 1)
             } else if isInfiniteScrollEnabled {
@@ -270,7 +270,7 @@ extension PageboyViewController: UIPageViewControllerDataSource {
             return nil
         }
 
-        if let index = currentIndex {
+        if let index = currentIndex, viewControllerCount > 1 {
             if index != viewControllerCount - 1 {
                 return fetchViewController(at: index + 1)
             } else if isInfiniteScrollEnabled {


### PR DESCRIPTION
If viewController is only one and infinite scroll, there was a situation that the view was not visible.
![May-21-2020 20-34-54](https://user-images.githubusercontent.com/25545112/82555370-967cf400-9ba2-11ea-9e9a-146ef0f0a194.gif)
