### PR TITLE
Fix crash within `UIPageViewController` during fast sequential page transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 `Pageboy` adheres to [Semantic Versioning](https://semver.org/).
 
 #### 4.x Releases
-- `4.0.x` Releases - [4.0.0](#400)
+- `4.0.x` Releases - [4.0.0](#400) | [4.0.1](#401)
 
 #### 3.x Releases
 - `3.7.x` Releases - [3.7.0](#370)
@@ -35,6 +35,13 @@ All notable changes to this project will be documented in this file.
 - `0.4.x` Releases - [0.4.0](#040) | [0.4.1](#041) | [0.4.2](#042) | [0.4.3](#043) | [0.4.4](#044) | [0.4.5](#045) | [0.4.6](#046) | [0.4.7](#047) | [0.4.8](#048) | [0.4.9](#049) | [0.4.10](#0410) | [0.4.11](#0411) | [0.4.12](#0412)
 
 ---
+## [4.0.1](https://github.com/uias/Pageboy/releases/tag/4.0.1)
+Released on 2022-XX-XX
+
+#### Fixed
+- Issue where `UIPageViewController` could crash during fast sequential transitions.
+     - by [BasBuijsen](https://github.com/BasBuijsen)
+
 ## [4.0.0](https://github.com/uias/Pageboy/releases/tag/4.0.0)
 Released on 2022-11-02
 

--- a/Sources/Pageboy/Utilities/PatchedPageViewController.swift
+++ b/Sources/Pageboy/Utilities/PatchedPageViewController.swift
@@ -9,11 +9,17 @@ import UIKit
 
 /// Fixes not updating dataSource on animated setViewControllers. See: https://stackoverflow.com/a/13253884/715593
 internal class PatchedPageViewController: UIPageViewController {
+
+    private var isAnimating = false
+
     override func setViewControllers(_ viewControllers: [UIViewController]?, direction: UIPageViewController.NavigationDirection, animated: Bool, completion: ((Bool) -> Void)? = nil) {
         super.setViewControllers(viewControllers, direction: direction, animated: animated) { (isFinished) in
-            if  isFinished && animated {
+            if isFinished && animated && !self.isAnimating {
+                self.isAnimating = true
                 DispatchQueue.main.async {
-                    super.setViewControllers(viewControllers, direction: direction, animated: false, completion: nil)
+                    super.setViewControllers(viewControllers, direction: direction, animated: false, completion: { _ in
+                        self.isAnimating = false
+                    })
                 }
             }
             


### PR DESCRIPTION
Resolves #277 