### PR TITLE
also add check isAnimating on first setViewControllers()

### DIFF
--- a/Sources/Pageboy/Utilities/PatchedPageViewController.swift
+++ b/Sources/Pageboy/Utilities/PatchedPageViewController.swift
@@ -13,17 +13,20 @@ internal class PatchedPageViewController: UIPageViewController {
     private var isAnimating = false
 
     override func setViewControllers(_ viewControllers: [UIViewController]?, direction: UIPageViewController.NavigationDirection, animated: Bool, completion: ((Bool) -> Void)? = nil) {
-        super.setViewControllers(viewControllers, direction: direction, animated: animated) { (isFinished) in
-            if isFinished && animated && !self.isAnimating {
-                self.isAnimating = true
-                DispatchQueue.main.async {
-                    super.setViewControllers(viewControllers, direction: direction, animated: false, completion: { _ in
-                        self.isAnimating = false
-                    })
+        if !self.isAnimating {
+            self.isAnimating = true
+            super.setViewControllers(viewControllers, direction: direction, animated: false) { (isFinished) in
+                if isFinished && animated && !self.isAnimating {
+                    self.isAnimating = true
+                    DispatchQueue.main.async {
+                        super.setViewControllers(viewControllers, direction: direction, animated: false, completion: { _ in
+                            self.isAnimating = !isFinished
+                        })
+                    }
                 }
+                
+                completion?(isFinished)
             }
-            
-            completion?(isFinished)
         }
     }
 }


### PR DESCRIPTION
@msaps The check for isAnimated should be on both levels of `super.setViewControllers(...)` to prevent the crash from [this issue](https://github.com/uias/Pageboy/issues/277 )