### PR TITLE
Run build workflow on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches-ignore:
       - "gh-pages"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   Test:
@@ -17,6 +22,4 @@ jobs:
           bundle update --bundler
           bundle install
       - name: Run tests
-        env:
-          SLACK_URL: ${{ secrets.SLACK_URL }}
         run: bundle exec fastlane test


### PR DESCRIPTION
Add a pull_request trigger so the build runs for internal PRs and forked contributor PRs. Remove the unused SLACK_URL secret from the test step so the workflow remains safe to execute without repository secrets.